### PR TITLE
#161967005 link GitHub to coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/andela/ah-jumanji/badge.svg?branch=link-coveralls)](https://coveralls.io/github/andela/ah-jumanji?branch=link-coveralls)
+
 Authors Haven - A Social platform for the creative at heart.
 =======
 
@@ -390,7 +392,3 @@ No additional parameters required
 ### Get Tags
 
 `GET /api/tags`
-
-
-
-


### PR DESCRIPTION
#### What does this PR do?
   - This PR links this repo to coveralls to show test coverage.

#### Any background context you want to provide?
   - The markdown generated by coveralls is put in a readme file.
   - By doing so, the coverage badge can now be displayed in the repo. 

#### What are the relevant pivotal tracker stories?
   [#161967005](https://www.pivotaltracker.com/story/show/161967005)

